### PR TITLE
Handle PHP 7 Error / Throwable

### DIFF
--- a/src/Backoff.php
+++ b/src/Backoff.php
@@ -239,6 +239,12 @@ class Backoff
             $this->wait($attempt);
             try {
                 $result = call_user_func($callback);
+            } catch (\Throwable $e) {
+                if ($e instanceof \Error) {
+                    $e = new Exception($e->getMessage(), $e->getCode(), $e);
+                }
+                $this->exceptions[] = $e;
+                $exception = $e;
             } catch (Exception $e) {
                 $this->exceptions[] = $e;
                 $exception = $e;

--- a/tests/BackoffTest.php
+++ b/tests/BackoffTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace STS\Backoff;
 
+use Exception;
 use PHPUnit\Framework\TestCase;
 use STS\Backoff\Strategies\ConstantStrategy;
 use STS\Backoff\Strategies\ExponentialStrategy;
@@ -186,6 +187,23 @@ class BackoffTest extends TestCase
 
         $b->run(function () {
             throw new \Exception("failure");
+        });
+    }
+
+    public function testHandleErrorsPhp7()
+    {
+        $b = new Backoff(2, new ConstantStrategy(0));
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Modulo by zero");
+
+        $b->run(function () {
+            if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
+                return 1 % 0;
+            } else {
+                // Handle version < 7
+                throw new Exception("Modulo by zero");
+            }
         });
     }
 


### PR DESCRIPTION
In PHP 7 Errors are thrown in a similar manner as Exceptions.

This PR makes backoff handle Throwable's (and keep backwards compatibility) (Issue #8).
