### PR TITLE
Add gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+.github export-ignore
+tests export-ignore
+.gitignore export-ignore
+.gitattributes export-ignore
+phpunit.xml export-ignore


### PR DESCRIPTION
Hi @jszobody 

There is no gitattributes here so when installing this lib the tests folder and some other useless files are downloaded.
<img width="230" alt="image" src="https://github.com/stechstudio/backoff/assets/9052536/2ae57f38-1fb7-4b82-9c69-fbfaf6c2f3ad">

The `export-ignore` directive allows to avoid downloading those files.