### PR TITLE
fix bug with longer waits

### DIFF
--- a/src/Backoff.php
+++ b/src/Backoff.php
@@ -307,7 +307,7 @@ class Backoff
             return;
         }
 
-        usleep($this->getWaitTime($attempt) * 1000);
+        usleep(intval($this->getWaitTime($attempt) * 1000));
     }
 
     /**


### PR DESCRIPTION
When the library encounters somewhat higher timeouts, it can crash with the following error (because it calculates a float value instead of a int value):

```
TypeError 

  usleep(): Argument #1 ($microseconds) must be of type int, float given

  at /var/app/vendor/stechstudio/backoff/src/Backoff.php:310
    306▕         if ($attempt == 0) {
    307▕             return;
    308▕         }
    309▕ 
  ➜ 310▕         usleep($this->getWaitTime($attempt) * 1000);
    311▕     }
    312▕ 
    313▕     /**
    314▕      * @param int $attempt

      +2 vendor frames 

  3   /var/app/app/Models/Testconfig.php:[92](https://github.com/elasticscale/elasticscale_module_deploy/actions/runs/8474497668/job/23220979717#step:7:93)
      STS\Backoff\Backoff::run()
```