### PR TITLE
Fix ExponentialStrategy calculation and update tests

### DIFF
--- a/src/Strategies/ExponentialStrategy.php
+++ b/src/Strategies/ExponentialStrategy.php
@@ -14,9 +14,6 @@ class ExponentialStrategy extends AbstractStrategy
      */
     public function getWaitTime($attempt)
     {
-        return (int) ($attempt == 1
-            ? $this->base
-            : pow(2, $attempt) * $this->base
-        );
+        return (int) ($this->base * (pow(2, $attempt - 1)));
     }
 }

--- a/tests/Strategies/ExponentialStrategyTest.php
+++ b/tests/Strategies/ExponentialStrategyTest.php
@@ -17,12 +17,21 @@ class ExponentialStrategyTest extends TestCase
         $s = new ExponentialStrategy(200);
 
         $this->assertEquals(200, $s->getWaitTime(1));
-        $this->assertEquals(800, $s->getWaitTime(2));
-        $this->assertEquals(1600, $s->getWaitTime(3));
-        $this->assertEquals(3200, $s->getWaitTime(4));
-        $this->assertEquals(6400, $s->getWaitTime(5));
-        $this->assertEquals(12800, $s->getWaitTime(6));
-        $this->assertEquals(25600, $s->getWaitTime(7));
-        $this->assertEquals(51200, $s->getWaitTime(8));
+        $this->assertEquals(400, $s->getWaitTime(2));
+        $this->assertEquals(800, $s->getWaitTime(3));
+        $this->assertEquals(1600, $s->getWaitTime(4));
+        $this->assertEquals(3200, $s->getWaitTime(5));
+        $this->assertEquals(6400, $s->getWaitTime(6));
+        $this->assertEquals(12800, $s->getWaitTime(7));
+        $this->assertEquals(25600, $s->getWaitTime(8));
+    }
+
+    public function testWaitTimesWithDefault()
+    {
+        $strategy = new ExponentialStrategy();
+        $base = $strategy->getBase();
+        $this->assertEquals((int) ($base * pow(2, 0)), $strategy->getWaitTime(1));
+        $this->assertEquals((int) ($base * pow(2, 1)), $strategy->getWaitTime(2));
+        $this->assertEquals((int) ($base * pow(2, 2)), $strategy->getWaitTime(3));
     }
 }


### PR DESCRIPTION
Fix: #18 

This PR addresses the issue #18 where the ExponentialStrategy was not correctly calculating the wait time for the first attempt. The changes include:

## Changes made:

```php
public function getWaitTime($attempt)
{
    return (int) ($this->base * (pow(2, $attempt - 1)));
}
```

This new implementation ensures that:
- The first attempt (attempt = 1) returns the base wait time
- Subsequent attempts follow the exponential backoff pattern correctly

Example with base time of 100ms:

- 1st attempt: 100ms
- 2nd attempt: 200ms
- 3rd attempt: 400ms
- 4th attempt: 800ms
- ...

## Potential impacts:

This change will affect the behavior of the ExponentialStrategy, particularly for the first attempt. Users who were relying on the previous behavior may need to adjust their expectations or configurations.

## What I've done:
- [x] PHPUnit locally (all tests passing)

I've tested this locally and everything looks good. Would really appreciate if you could take a look when you have a moment. Let me know if you need anything else!