### PR TITLE
Added protection against overflows in the wait time calculation.

### DIFF
--- a/src/Backoff.php
+++ b/src/Backoff.php
@@ -329,6 +329,7 @@ class Backoff
      */
     protected function cap($waitTime)
     {
+        $waitTime = $waitTime < 0 ? PHP_INT_MAX : $waitTime;
         return is_int($this->getWaitCap())
             ? min($this->getWaitCap(), $waitTime)
             : $waitTime;

--- a/tests/BackoffTest.php
+++ b/tests/BackoffTest.php
@@ -151,6 +151,13 @@ class BackoffTest extends TestCase
         $this->assertEquals(5000, $b->getWaitTime(2));
     }
 
+    public function testWaitCapOverflow()
+    {
+        $b = new Backoff(1, new LinearStrategy(-1), 1000);
+
+        $this->assertEquals(1000, $b->getWaitTime(1));
+    }
+
     public function testWait()
     {
         $b = new Backoff(1, new LinearStrategy(50));


### PR DESCRIPTION
This adds overflow protection to the cap function. This effectively prevents negative wait times to be returned which would cause unintended consequences. For example, if jitter is enabled the execution will break due to `mt_rand()` being called with bad parameters.

Example:
```
Fatal error: Uncaught ValueError: mt_rand(): Argument #2 ($max) must be greater than or equal to argument #1 ($min)
```

Wait time can overflow if the strategy used is called with high enough attempts. Example here:
```php
$strategy = new STS\Backoff\Strategies\ExponentialStrategy(100);
echo $strategy->getWaitTime(58);
```
Output:
```
-4035225266123964416
```

The remedy applied in this PR effectively replaces any negative wait time with the max available one, assuming an overflow has occurred.