### PR TITLE
add phpstan return and template annotations

### DIFF
--- a/src/Backoff.php
+++ b/src/Backoff.php
@@ -223,8 +223,10 @@ class Backoff
     }
 
     /**
-     * @param callable $callback
+     * @template T
+     * @param callable():T $callback
      *
+     * @phpstan-return (T is void ? null : T)
      * @return mixed
      * @throws Exception
      */


### PR DESCRIPTION
Hi! We're using Backoff in a project and I came across an issue where the return type `mixed` of `Backoff::run()` messes with the type inference of phpstan. If you have something like this:

```php 
function test(): string
{
    return (new STS\Backoff\Backoff())->run(
        function (): string {
            return "Success!";
        }
    );
}
```

PHPStan will argue: `Function test() should return string but returns mixed.`

The argument here is easy: We know the return type, because it is given as the return type of the `$callback` argument. We should be able to proxy this type to phpstan!

So this PR is adding annotations to the Backoff::run() to allow it to proxy these types.